### PR TITLE
[PACKAGE] Fix synchronizer package path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "synchronizer"]
 	path = synchronizer
-	url = git@github.com:dkonovenschi/aggretastic-sync.git
+	url = git@github.com:konovenschi/aggretastic-sync.git


### PR DESCRIPTION
After account renaming the path of synchronizer package became broken. This PR contain fix for this path